### PR TITLE
make the device files be owned by the group 'plugdev'

### DIFF
--- a/udev/69-mooltipass.rules
+++ b/udev/69-mooltipass.rules
@@ -2,10 +2,10 @@
 ACTION!="add|change", GOTO="mooltipass_end"
 
 # console user
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", SYMLINK+="mooltipass_keyboard", TAG+="uaccess", TAG+="udev-acl"
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="4321", MODE="0660", SYMLINK+="mooltipass_keyboard", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", GROUP="plugdev", SYMLINK+="mooltipass_keyboard", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="4321", MODE="0660", GROUP="plugdev", SYMLINK+="mooltipass_keyboard", TAG+="uaccess", TAG+="udev-acl"
 # libusb
-SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", SYMLINK+="mooltipass_device", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="4321", MODE="0660", SYMLINK+="mooltipass_device", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", GROUP="plugdev", SYMLINK+="mooltipass_device", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="4321", MODE="0660", GROUP="plugdev", SYMLINK+="mooltipass_device", TAG+="uaccess"
 
 LABEL="mooltipass_end"


### PR DESCRIPTION
By default on my machine (Void Linux), the device files are owned by root:root. With the GROUP="0660" statement, this doesn't really help much. Instead, the files need to be root:plugdev in order for eg. FIDO2 support to work correctly.