### PR TITLE
(fix)Add rule required for newer versions of bluez

### DIFF
--- a/udev/69-mooltipass.rules
+++ b/udev/69-mooltipass.rules
@@ -8,4 +8,7 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="4321", MODE="06
 SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", SYMLINK+="mooltipass_device", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="4321", MODE="0660", SYMLINK+="mooltipass_device", TAG+="uaccess"
 
+# required for newer versions of bluez
+SUBSYSTEM=="hidraw", KERNELS=="*1209:4321*", MODE="0660", SYMLINK+="mooltipass_keyboard", TAG+="uaccess", TAG+="udev-acl"
+
 LABEL="mooltipass_end"


### PR DESCRIPTION
This rule is required for newer versions of bluez which no longer seem to set the vendor and product id attributes for these events.

Fixes https://github.com/mooltipass/mooltipass-udev/issues/2